### PR TITLE
Add filtering for redirects #4

### DIFF
--- a/controllers/redirects/config_filter.yaml
+++ b/controllers/redirects/config_filter.yaml
@@ -34,3 +34,13 @@ scopes:
         modelClass: Vdlp\Redirect\Models\Category
         conditions: category_id in (:filtered)
         nameFrom: name
+    hits:
+        label: vdlp.redirect::lang.redirect.has_hits
+        type: switch
+        conditions:
+            - hits = 0
+            - hits <> 0
+    minimum_hits:
+        label: vdlp.redirect::lang.redirect.minimum_hits
+        type: number
+        conditions: hits >= ':filtered'

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -102,6 +102,8 @@ return [
             . 'Redirects will not be cached.',
         'general_confirm' => 'Are you sure you want to do this?',
         'sparkline_30d' => 'Hits (30d)',
+        'has_hits' => 'Has hits',
+        'minimum_hits' => 'Minimum # hits',
     ],
     'list' => [
         'no_records' => 'There are no redirects in this view.',

--- a/lang/es/lang.php
+++ b/lang/es/lang.php
@@ -103,6 +103,8 @@ return [
             . 'Redirects will not be cached.',
         'general_confirm' => 'Are you sure you want to do this?', // TODO
         'sparkline_30d' => 'Hits (30d)', // TODO
+        'has_hits' => 'Has hits', // TODO
+        'minimum_hits' => 'Minimum # hits', // TODO
     ],
     'list' => [
         'no_records' => 'No hay redirecciones en esta vista.',

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -103,6 +103,8 @@ return [
             . 'Redirects will not be cached.',
         'general_confirm' => 'Are you sure you want to do this?', // TODO
         'sparkline_30d' => 'Hits (30d)', // TODO
+        'has_hits' => 'Has hits', // TODO
+        'minimum_hits' => 'Minimum # hits', // TODO
     ],
     'list' => [
         'no_records' => 'Il n\'y a pas de redirections dans cette vue.',

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -102,6 +102,8 @@ return [
             . 'Redirects zullen niet worden gecached.',
         'general_confirm' => 'Weet je het zeker?',
         'sparkline_30d' => 'Treffers (30d)',
+        'has_hits' => 'Heeft treffers',
+        'minimum_hits' => 'Minimum treffers',
     ],
     'list' => [
         'no_records' => 'Er zijn geen redirects in dit beeld.',

--- a/lang/ru/lang.php
+++ b/lang/ru/lang.php
@@ -100,6 +100,8 @@ return [
             . 'Redirects will not be cached.',
         'general_confirm' => 'Are you sure you want to do this?', // TODO
         'sparkline_30d' => 'Hits (30d)', // TODO
+        'has_hits' => 'Has hits', // TODO
+        'minimum_hits' => 'Minimum # hits', // TODO
     ],
     'list' => [
         'no_records' => 'В этом списке нет редиректов.',

--- a/lang/sv/lang.php
+++ b/lang/sv/lang.php
@@ -100,6 +100,8 @@ return [
             . 'Redirects will not be cached.',
         'general_confirm' => 'Are you sure you want to do this?', // TODO
         'sparkline_30d' => 'Hits (30d)', // TODO
+        'has_hits' => 'Has hits', // TODO
+        'minimum_hits' => 'Minimum # hits', // TODO
     ],
     'list' => [
         'no_records' => 'Det finns inga ompekningar i denna vy',


### PR DESCRIPTION
Resolves issue #4.

- Filter using a switch for redirects with hits, without hits or both.
- Filter with a number input for minimum hits.

Notes:
- Translated the added filters to Dutch and English. Added the English translations to the other supported languages with TODO's.