### PR TITLE
Explicitly ask for only read permission

### DIFF
--- a/classes/RedirectManager.php
+++ b/classes/RedirectManager.php
@@ -615,7 +615,7 @@ final class RedirectManager implements RedirectManagerInterface
         }
 
         /** @var Reader $reader */
-        $reader = Reader::createFromPath($rulesPath);
+        $reader = Reader::createFromPath($rulesPath, 'r');
 
         // WARNING: this is deprecated method in league/csv:8.0, when league/csv is upgraded to version 9 we should
         // follow the instructions on this page: http://csv.thephpleague.com/upgrading/9.0/


### PR DESCRIPTION
This fixes an issue where redirects will fail to work when the redirects.csv file does not have the write permission. Note that this was happening randomly on a server the file was set with the below permissions and was perfectly capable of writing to the file (in fact a temporary fix every time the redirects broke was to regenerate the file by clicking "Enable All Redirects" in the backend)
`-rw-r--r--  1 www-data www-data  6805 Oct  3 17:57 redirects.csv`

Docs for why this is required here: https://csv.thephpleague.com/8.0/reading/