### PR TITLE
Add next major OctoberCMS release support

### DIFF
--- a/classes/RedirectManager.php
+++ b/classes/RedirectManager.php
@@ -10,7 +10,7 @@ use Cms\Classes\Controller;
 use Cms\Classes\Theme;
 use Cms\Helpers\Cms;
 use Exception;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface as Log;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
 use League\Csv\Reader;

--- a/classes/RedirectMiddleware.php
+++ b/classes/RedirectMiddleware.php
@@ -6,7 +6,7 @@ namespace Vdlp\Redirect\Classes;
 
 use Closure;
 use Exception;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface as Log;
 use Illuminate\Http\Request;
 use October\Rain\Events\Dispatcher;
 use Vdlp\Redirect\Classes\Contracts\RedirectConditionInterface;


### PR DESCRIPTION
The next major release of OctoberCMS will cause some trouble: Target class [Illuminate\Contracts\Logging\Log] does not exist.

This is due to a update on Laravel 5.6, more information here: https://laravel.com/docs/5.6/upgrade
>This interface has been removed since this interface was a total duplication of the Psr\Log\LoggerInterface interface. You should type-hint the Psr\Log\LoggerInterface interface instead.