### PR TITLE
Flush cache when a redirect rule is updated.

### DIFF
--- a/classes/PublishManager.php
+++ b/classes/PublishManager.php
@@ -114,6 +114,7 @@ final class PublishManager implements PublishManagerInterface
 
         unset($redirect);
 
+        $this->cacheManager->flush();
         $this->cacheManager->putRedirectRules($redirects);
     }
 }


### PR DESCRIPTION
Fixes #54 

I am using the cache manager flush method here because this is the only feasible way to ensure all of the correct redirect rules are flushed from cache as it is not so easy to clear based on a single redirect rule as a single redirect rule can have multiple different cache keys since the cache keys are based on path and scheme.

For instance, if you have a regex redirect rule, that could potentially have thousands of different cache keys that you would need to calculate and clear one by one. So, flushing the cache is the quickest  and most simple way.

I decided to call the flush method in the PublishManager publishToCache method specifically because it is the latest it can be called before the new rules are put into cache, this should help avoid race conditions as much as can be, since flushing the cache before the foreach loop could take a little bit of time depending on how many redirect rules are present and a user could hit a redirect rule while that loop is running and cause a new cache entry to be created and thus is never fully cleared from cache.


Hope this makes sense and is an acceptable solution.