### PR TITLE
Fixes issue occuring with output_buffering causing Laravel to override original header redirect.

### DIFF
--- a/classes/RedirectManager.php
+++ b/classes/RedirectManager.php
@@ -196,6 +196,13 @@ final class RedirectManager implements RedirectManagerInterface
         header('Cache-Control: no-store');
         header('Location: ' . $toUrl, true, $statusCode);
 
+        // Ensure any headers declared up to this point are sent
+        // before Laravel core or something else has a chance to overwrite them.
+        if (ob_get_level() > 0) {
+            ob_flush();
+            flush();
+        }
+
         exit(0);
     }
 


### PR DESCRIPTION
Resolves issues occuring where redirect was getting output but something was overriding the end result and would result in a 404 result.