### PR TITLE
Re-publish redirect rules if cache has been cleared.

### DIFF
--- a/classes/CacheManager.php
+++ b/classes/CacheManager.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Cache\Repository;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use Vdlp\Redirect\Classes\Contracts\CacheManagerInterface;
+use Vdlp\Redirect\Classes\Contracts\PublishManagerInterface;
 use Vdlp\Redirect\Models\Settings;
 
 final class CacheManager implements CacheManagerInterface
@@ -69,6 +70,11 @@ final class CacheManager implements CacheManagerInterface
 
     public function getRedirectRules(): array
     {
+        if (! $this->cache->tags(self::CACHE_TAG_RULES)->has('rules')) {
+            $publishManager = app(PublishManagerInterface::class);
+            $publishManager->publish();
+        }
+
         $data = $this->cache->tags(self::CACHE_TAG_RULES)
             ->get('rules', []);
 


### PR DESCRIPTION
Fixes #77 

If the cache has been cleared, then re-fetching the rules from cache will result in an empty array and cause all redirects to stop working.

Redirect rules need to be re-published if the rules cache key does not exist when re-fetching the rules from the cache once it has been cleared.