### PR TITLE
Fixed config_filter.yaml for MySQL >= 8.0.3

### DIFF
--- a/controllers/redirects/config_filter.yaml
+++ b/controllers/redirects/config_filter.yaml
@@ -3,8 +3,8 @@ scopes:
         label: vdlp.redirect::lang.list.switch_system
         type: switch
         conditions:
-            - system <> true
-            - system = true
+            - "`system` <> true"
+            - "`system` = true"
     is_enabled:
         label: vdlp.redirect::lang.list.switch_is_enabled
         type: switch


### PR DESCRIPTION
`SYSTEM` is a reserved word since MySQL 8.0.3. If a user enables the [System Filter](https://github.com/vdlp/oc-redirect-plugin/blob/cd137f1a2d4ec096fb9db7f04a73a6f475d216af/controllers/redirects/config_filter.yaml#L6) the generated query will fail.