### PR TITLE
Allow October v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "davaxi/sparkline": "^2.0",
         "jaybizzle/crawler-detect": "^1.2",
         "league/csv": "^9.0",
-        "october/rain": "^3.0",
+        "october/rain": "^3.0 || ^4.0",
         "symfony/stopwatch": "^6.0"
     },
     "repositories": [


### PR DESCRIPTION
Currently, when upgrading a project from v3 to v4, this plugin will be downgraded to [v3.0.4](https://github.com/vdlp/oc-redirect-plugin/releases/tag/3.0.4): the last version that didn't have a constraint on the OCMS version.

This fix would allow the latest version to be installed on OCMS v4.